### PR TITLE
Gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# text files with either LF or CRLF depending on platform (Unix/Linux, and Windows respectively)
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+.git* text
+README text
+TODO text
+*.wb text
+.v text
+*.vhd text
+*.vhdl text
+*.mpf text
+
+# Declare files that will always have LF line endings
+Makefile text eol=lf
+squishy text eol=lf
+squish text eol=lf
+wbgen2 text eol=lf
+*.lua text eol=lf
+*.py text eol=lf
+*.sh text eol=lf
+*.do text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 README text
 TODO text
 *.wb text
-.v text
+*.v text
 *.vhd text
 *.vhdl text
 *.mpf text


### PR DESCRIPTION
Add a `.gitattributes` file that sets proper Unix line endings even when clones in a Windows environment. This is necessary for making the `wbgen2` utility under Windows Subsystem for Linux. Without this file, the line endings for Linux files (LF) are converted to Windows line endings (CRLF). This causes squishy to fail, and even if that is fixed, the resulting `wbgen2` has mixed line endings depending on how the types present on each Lua source file.

The .gitattributes file forces Linux line endings on the following file extensions:`.lua`, `.py`, `.sh`, `.do`. And also the `Makefile`, `squishy`, `squish`, and `wbgen2`.
