### PR TITLE
Origin/fix verilog init

### DIFF
--- a/wbgen2
+++ b/wbgen2
@@ -4496,7 +4496,9 @@ if(options.output_hdl_file~=nil)then
 if(options.lang=="vhdl")then
 cgen_generate_vhdl_code(tree);
 elseif(options.lang=="verilog")then
+cgen_generate_init(options.output_hdl_file);
 cgen_generate_verilog_code(tree);
+cgen_generate_done();
 end
 end
 if(options.output_c_header_file~=nil)then

--- a/wbgen_main.lua
+++ b/wbgen_main.lua
@@ -214,7 +214,9 @@ if(options.output_hdl_file ~= nil) then
    if (options.lang == "vhdl") then
       cgen_generate_vhdl_code(tree);
    elseif (options.lang == "verilog") then
+	  cgen_generate_init(options.output_hdl_file);
       cgen_generate_verilog_code(tree);
+	  cgen_generate_done();
    end
 end
 


### PR DESCRIPTION
For some reason the original project was missing Verilog output command. This pull request adds this capability.