### PR TITLE
Implement configurable bus width

### DIFF
--- a/cgen_c_headers.lua
+++ b/cgen_c_headers.lua
@@ -17,6 +17,14 @@
 -- NAME_R - read access macro extracting the value of certain field from the register: 
 -- field1_value = FIELD1_R(regs_struct->reg);
 --
+
+uint_t = {
+   [8]  = "uint8_t",
+   [16] = "uint16_t",
+   [32] = "uint32_t",
+   [64] = "uint64_t"
+}
+
 function cgen_c_field_define(field, reg)
    local prefix;
    -- anonymous field?
@@ -136,7 +144,7 @@ function cgen_c_struct()
    function pad_struct(base)
       if(cur_offset < base) then
 	 emit("/* padding to: "..base.." words */");
-	 emit("uint32_t __padding_"..pad_id.."["..(base - cur_offset).."];");
+	 emit(uint_t[DATA_BUS_WIDTH].." __padding_"..pad_id.."["..(base - cur_offset).."];");
 	 pad_id=pad_id+1;
 	 cur_offset = base;
       end
@@ -155,7 +163,7 @@ function cgen_c_struct()
 			      emit(string.format("/* [0x%x]: REG "..reg.name.." */", reg.base * DATA_BUS_WIDTH / 8));
 			      
 			      -- this is just simple :)
-			      emit("uint32_t "..string.upper(reg.c_prefix)..";");
+			      emit(uint_t[DATA_BUS_WIDTH].." "..string.upper(reg.c_prefix)..";");
 			      cur_offset = cur_offset + 1;
 			   end);
    
@@ -184,7 +192,7 @@ function cgen_c_struct()
 			      if(ram.byte_select) then
 				 emit("uint8_t "..string.upper(ram.c_prefix).." ["..(ram.size * (DATA_BUS_WIDTH/8) * math.pow(2, ram.wrap_bits)) .."];");
 			      else
-				 emit("uint32_t "..string.upper(ram.c_prefix).." ["..(ram.size * math.pow(2, ram.wrap_bits)) .."];");									
+				 emit(uint_t[DATA_BUS_WIDTH].." "..string.upper(ram.c_prefix).." ["..(ram.size * math.pow(2, ram.wrap_bits)) .."];");									
 			      end
 			   end);
    

--- a/examples/wishbone_widths/.gitignore
+++ b/examples/wishbone_widths/.gitignore
@@ -1,0 +1,3 @@
+docs/
+include/
+rtl/

--- a/examples/wishbone_widths/Makefile
+++ b/examples/wishbone_widths/Makefile
@@ -1,0 +1,51 @@
+# Wishbone generator
+WBGEN = wbgen2
+
+# Wishbone generator flags
+WBGENFLAGS = -lverilog
+
+# Directory where generated include files will be stored
+INCLUDE_DIR = include
+# Directory where generated documentation will be stored
+DOCU_DIR = docs
+# Directory where generated HDL code will be store
+RTL_DIR = rtl
+
+# Source directory
+SRC_DIR = .
+# Source files
+SRC_FILES = $(wildcard $(SRC_DIR)/*.wb)
+
+# Include files (generated)
+INCLUDE_FILES = $(patsubst $(SRC_DIR)/%.wb, $(INCLUDE_DIR)/%.h, $(SRC_FILES))
+# Documentation files (generated)
+DOCU_FILES = $(patsubst $(SRC_DIR)/%.wb, $(DOCU_DIR)/%.htm, $(SRC_FILES))
+# RTL files (generated)
+RTL_FILES = $(patsubst $(SRC_DIR)/%.wb, $(RTL_DIR)/%.v, $(SRC_FILES))
+
+all: $(INCLUDE_FILES) $(DOCU_FILES) $(RTL_FILES)
+
+# Rule to create include files
+$(INCLUDE_DIR)/%.h: $(SRC_DIR)/%.wb | $(INCLUDE_DIR)
+	$(WBGEN) $(WBGENFLAGS) -C$@ $<
+
+# Rule to create documentation files
+$(DOCU_DIR)/%.htm: $(SRC_DIR)/%.wb | $(DOCU_DIR)
+	$(WBGEN) $(WBGENFLAGS) -D$@ $<
+
+# Rule to create include files
+$(RTL_DIR)/%.v: $(SRC_DIR)/%.wb | $(RTL_DIR)
+	$(WBGEN) $(WBGENFLAGS) -V$@ $<
+
+$(INCLUDE_DIR):
+	mkdir -p $(INCLUDE_DIR)
+$(DOCU_DIR):
+	mkdir -p $(DOCU_DIR)
+$(RTL_DIR):
+	mkdir -p $(RTL_DIR)
+
+
+clean:
+	rm -rf $(INCLUDE_FILES) $(DOCU_FILES) $(RTL_FILES)
+
+.PHONY: all clean

--- a/examples/wishbone_widths/gpio_port_16.wb
+++ b/examples/wishbone_widths/gpio_port_16.wb
@@ -1,0 +1,73 @@
+peripheral {
+	name = "GPIO Port";
+	description = "A sample 16-bit general-purpose bidirectional I/O port, explaining how to use SLV and PASS-THROUGH registers.";
+	hdl_entity = "wb_slave_gpio_port";
+	prefix = "gpio";
+	wishbone_width = 16;
+
+	reg {
+		name = "Pin direction register";
+		description = "A register defining the direction of the GPIO potr pins.";
+		prefix = "ddr";
+
+		field {
+			name = "Pin directions";
+			description = "Each bit in this register defines the direction of corresponding pin of the GPIO port. 1 means the pin is an OUTPUT, 0 means the pin is an INPUT";
+			type = SLV;
+			size = 16;
+			access_bus = READ_WRITE;
+			access_dev = READ_ONLY;
+		};
+	};
+
+	reg {
+		name = "Pin input state register";
+		description = "A register containing the current state of input pins.";
+		prefix = "psr";
+		field {
+			name = "Pin input state";
+			description = "Each bit in this register reflects the state of corresponding GPIO port pin.";
+			type = SLV;
+			size = 16;
+			access_bus = READ_ONLY;
+			access_dev = WRITE_ONLY;
+		};
+	};
+	reg {
+		name = "Port output register";
+		description = "Register containing the output pin state.";
+		prefix = "pdr";
+		field {
+			name = "Port output value";
+--			description = "Writing '1' sets the corresponding GPIO pin to '1'";
+			type = PASS_THROUGH;
+			size = 16;
+		};
+	};
+
+
+	reg {
+		name = "Set output pin register";
+		description = "Writing '1' sets the corresponding GPIO pin to '1'";
+		prefix = "sopr";
+-- Our driver developer would want these two (SOPR and COPR) registers' addresses to be aligned to multiple of 4 :)
+		align = 4;
+		field {
+			name = "Set output pin register";
+			type = PASS_THROUGH;
+			size = 16;
+		};
+	};
+
+-- Clear output register. Designed identically as the previous reg.
+	reg {
+		name = "Clear output pin register";
+		description = "Writing '1' clears the corresponding GPIO pin";
+		prefix = "copr";
+		field {
+			name = "Clear output pin register";
+			type = PASS_THROUGH;
+			size = 16;
+		};
+	};
+};

--- a/examples/wishbone_widths/gpio_port_32.wb
+++ b/examples/wishbone_widths/gpio_port_32.wb
@@ -1,0 +1,72 @@
+peripheral {
+	name = "GPIO Port";
+	description = "A sample 32-bit general-purpose bidirectional I/O port, explaining how to use SLV and PASS-THROUGH registers.";
+	hdl_entity = "wb_slave_gpio_port";
+	prefix = "gpio";
+
+	reg {
+		name = "Pin direction register";
+		description = "A register defining the direction of the GPIO potr pins.";
+		prefix = "ddr";
+
+		field {
+			name = "Pin directions";
+			description = "Each bit in this register defines the direction of corresponding pin of the GPIO port. 1 means the pin is an OUTPUT, 0 means the pin is an INPUT";
+			type = SLV;
+			size = 32;
+			access_bus = READ_WRITE;
+			access_dev = READ_ONLY;
+		};
+	};
+
+	reg {
+		name = "Pin input state register";
+		description = "A register containing the current state of input pins.";
+		prefix = "psr";
+		field {
+			name = "Pin input state";
+			description = "Each bit in this register reflects the state of corresponding GPIO port pin.";
+			type = SLV;
+			size = 32;
+			access_bus = READ_ONLY;
+			access_dev = WRITE_ONLY;
+		};
+	};
+	reg {
+		name = "Port output register";
+		description = "Register containing the output pin state.";
+		prefix = "pdr";
+		field {
+			name = "Port output value";
+--			description = "Writing '1' sets the corresponding GPIO pin to '1'";
+			type = PASS_THROUGH;
+			size = 32;
+		};
+	};
+
+
+	reg {
+		name = "Set output pin register";
+		description = "Writing '1' sets the corresponding GPIO pin to '1'";
+		prefix = "sopr";
+-- Our driver developer would want these two (SOPR and COPR) registers' addresses to be aligned to multiple of 4 :)
+		align = 4;
+		field {
+			name = "Set output pin register";
+			type = PASS_THROUGH;
+			size = 32;
+		};
+	};
+
+-- Clear output register. Designed identically as the previous reg.
+	reg {
+		name = "Clear output pin register";
+		description = "Writing '1' clears the corresponding GPIO pin";
+		prefix = "copr";
+		field {
+			name = "Clear output pin register";
+			type = PASS_THROUGH;
+			size = 32;
+		};
+	};
+};

--- a/examples/wishbone_widths/gpio_port_64.wb
+++ b/examples/wishbone_widths/gpio_port_64.wb
@@ -1,0 +1,73 @@
+peripheral {
+	name = "GPIO Port";
+	description = "A sample 64-bit general-purpose bidirectional I/O port, explaining how to use SLV and PASS-THROUGH registers.";
+	hdl_entity = "wb_slave_gpio_port";
+	prefix = "gpio";
+	wishbone_width = 64;
+
+	reg {
+		name = "Pin direction register";
+		description = "A register defining the direction of the GPIO potr pins.";
+		prefix = "ddr";
+
+		field {
+			name = "Pin directions";
+			description = "Each bit in this register defines the direction of corresponding pin of the GPIO port. 1 means the pin is an OUTPUT, 0 means the pin is an INPUT";
+			type = SLV;
+			size = 64;
+			access_bus = READ_WRITE;
+			access_dev = READ_ONLY;
+		};
+	};
+
+	reg {
+		name = "Pin input state register";
+		description = "A register containing the current state of input pins.";
+		prefix = "psr";
+		field {
+			name = "Pin input state";
+			description = "Each bit in this register reflects the state of corresponding GPIO port pin.";
+			type = SLV;
+			size = 64;
+			access_bus = READ_ONLY;
+			access_dev = WRITE_ONLY;
+		};
+	};
+	reg {
+		name = "Port output register";
+		description = "Register containing the output pin state.";
+		prefix = "pdr";
+		field {
+			name = "Port output value";
+--			description = "Writing '1' sets the corresponding GPIO pin to '1'";
+			type = PASS_THROUGH;
+			size = 64;
+		};
+	};
+
+
+	reg {
+		name = "Set output pin register";
+		description = "Writing '1' sets the corresponding GPIO pin to '1'";
+		prefix = "sopr";
+-- Our driver developer would want these two (SOPR and COPR) registers' addresses to be aligned to multiple of 16 :)
+		align = 4;
+		field {
+			name = "Set output pin register";
+			type = PASS_THROUGH;
+			size = 64;
+		};
+	};
+
+-- Clear output register. Designed identically as the previous reg.
+	reg {
+		name = "Clear output pin register";
+		description = "Writing '1' clears the corresponding GPIO pin";
+		prefix = "copr";
+		field {
+			name = "Clear output pin register";
+			type = PASS_THROUGH;
+			size = 64;
+		};
+	};
+};

--- a/wbgen2
+++ b/wbgen2
@@ -1,8 +1,8 @@
 #!/usr/bin/env lua
 package.preload['alt_getopt']=(function(...)
-local n,d,u,a,o=type,pairs,ipairs,io,os
+local o,d,u,a,i=type,pairs,ipairs,io,os
 module("alt_getopt")
-local function i(t)
+local function c(t)
 local e=1
 local e=#t
 local e={}
@@ -13,7 +13,7 @@ return e
 end
 local function r(t,e)
 a.stderr:write(t)
-o.exit(e)
+i.exit(e)
 end
 local function a(e)
 r("Unknown option `-"..
@@ -23,7 +23,7 @@ local function l(t,e)
 if not t[e]then
 a(e)
 end
-while n(t[e])=="string"do
+while o(t[e])=="string"do
 e=t[e]
 if not t[e]then
 a(e)
@@ -36,7 +36,7 @@ local t=1
 local e=1
 local o={}
 local h={}
-local i=i(a)
+local i=c(a)
 for e,t in d(s)do
 i[e]=t
 end
@@ -104,12 +104,12 @@ return o,t,h
 end
 function get_opts(a,t,o)
 local e={}
-local t,i,o=get_ordered_opts(a,t,o)
-for t,a in u(t)do
-if o[t]then
-e[a]=o[t]
+local t,i,a=get_ordered_opts(a,t,o)
+for t,o in u(t)do
+if a[t]then
+e[o]=a[t]
 else
-e[a]=1
+e[o]=1
 end
 end
 return e,i
@@ -176,20 +176,20 @@ die(t.." expected.");
 end
 return e;
 end
-function range2bits(e)
-local t=e[1];
-local a=e[2];
-local e;
-if(math.abs(t)>math.abs(a))then
-e=math.abs(t);
+function range2bits(t)
+local e=t[1];
+local a=t[2];
+local t;
+if(math.abs(e)>math.abs(a))then
+t=math.abs(e);
 else
-e=math.abs(a);
+t=math.abs(a);
 end
-local e=math.ceil(math.log(e)/math.log(2));
-if(t<0)then
-e=e+1;
+local t=math.ceil(math.log(t)/math.log(2));
+if(e<0)then
+t=t+1;
 end
-return e;
+return t;
 end
 function calc_size(e,a)
 if(e.type==MONOSTABLE or e.type==BIT)then
@@ -214,14 +214,14 @@ die("ENUM-type fields are not yet supported. Sorry :(");
 end
 a.total_size=a.total_size+e.size;
 end
-function foreach_reg(a,t,e)
+function foreach_reg(t,a,e)
 if(e==nil)then
 e=periph;
 end
 for o,e in ipairs(e)do
 if(type(e)=='table')then
-if(e.__type~=nil and(match(e.__type,a)))then
-t(e);
+if(e.__type~=nil and(match(e.__type,t)))then
+a(e);
 end
 end
 end
@@ -285,22 +285,22 @@ function die(e)
 print("Error: "..e);
 os.exit(-1);
 end
-function match(e,t)
+function match(t,e)
 local a,a;
-for a,t in pairs(t)do
-if(e==t)then return true;end
+for a,e in pairs(e)do
+if(t==e)then return true;end
 end
 return false;
 end
-function inset(t,e)
-for a,e in ipairs(e)do if(t==e)then return true;end end
+function inset(e,t)
+for a,t in ipairs(t)do if(e==t)then return true;end end
 return false;
 end
-function csel(e,a,t)
-if(e)then
-return a;
-else
+function csel(a,t,e)
+if(a)then
 return t;
+else
+return e;
 end
 end
 function check_field_types(e)
@@ -321,6 +321,19 @@ end
 e.c_prefix=e.prefix;
 e.hdl_prefix=e.prefix;
 return e;
+end
+return e;
+end
+function default_wishbone_width(e)
+if(e.__type~=TYPE_PERIPH)then
+return e;
+elseif(e.wishbone_width~=nil)then
+local t={[8]=true,[16]=true,[32]=true,[64]=true};
+if not t[e.wishbone_width]then
+die("Invalid wishbone bus width '"..e.name.."'");
+end
+else
+e.wishbone_width=32;
 end
 return e;
 end
@@ -404,19 +417,19 @@ end
 function assign_addresses()
 local o=math.max(max_ram_addr_bits,log2up(all_regs_size));
 local e=num_rams;
-local t=0;
+local a=0;
 if(all_regs_size>0)then
 e=e+1;
 end
-local a=log2up(e);
+local t=log2up(e);
 foreach_reg({TYPE_REG,TYPE_FIFO},function(e)
 if(e.__type==TYPE_REG)then
-e.base=align(e,t);
-t=e.base+1;
+e.base=align(e,a);
+a=e.base+1;
 end
 end);
-address_bus_width=o+a;
-address_bus_select_bits=a;
+address_bus_width=o+t;
+address_bus_select_bits=t;
 end
 function find_max(e,a)
 local t=0;
@@ -432,28 +445,28 @@ table.insert(t,e);
 end
 end
 function tree_2_table(e)
-local a={};
-foreach_reg({TYPE_REG,TYPE_RAM,TYPE_FIFO,TYPE_IRQ},function(t)
-if(t[e]~=nil)then
-if(type(t[e])=='table')then
-table_join(a,t[e]);
+local t={};
+foreach_reg({TYPE_REG,TYPE_RAM,TYPE_FIFO,TYPE_IRQ},function(a)
+if(a[e]~=nil)then
+if(type(a[e])=='table')then
+table_join(t,a[e]);
 else
-table.insert(a,t[e]);
+table.insert(t,a[e]);
 end
 end
-foreach_subfield(t,function(t,o)
-if(t[e]~=nil)then
-if(type(t[e])=='table')then
-table_join(a,t[e]);
+foreach_subfield(a,function(a,o)
+if(a[e]~=nil)then
+if(type(a[e])=='table')then
+table_join(t,a[e]);
 else
-table.insert(a,t[e]);
+table.insert(t,a[e]);
 end
 end
 end);
 end);
-return a;
+return t;
 end
-function remove_duplicates(o)
+function remove_duplicates(a)
 function count_entries(t,a)
 local o,o,e;
 e=0;
@@ -461,7 +474,7 @@ for o,t in ipairs(t)do if(t==a)then e=e+1;end end
 return e;
 end
 local e={};
-for a,t in ipairs(o)do
+for a,t in ipairs(a)do
 local a=count_entries(e,t);
 if(a==0)then
 table.insert(e,t);
@@ -471,59 +484,59 @@ return e;
 end
 function wbgen_count_subblocks()
 local e=0;
-local t=0;
 local a=0;
+local t=0;
 local o=0;
 foreach_reg({TYPE_RAM},function(t)e=e+1;end);
-foreach_reg({TYPE_REG},function(e)a=a+1;end);
-foreach_reg({TYPE_FIFO},function(e)t=t+1;end);
+foreach_reg({TYPE_REG},function(e)t=t+1;end);
+foreach_reg({TYPE_FIFO},function(e)a=a+1;end);
 foreach_reg({TYPE_IRQ},function(e)o=o+1;end);
 periph.ramcount=e;
-periph.fifocount=t;
-periph.regcount=a;
+periph.fifocount=a;
+periph.regcount=t;
 periph.irqcount=o;
-if(e+t+a+o==0)then
+if(e+a+t+o==0)then
 die("Can't generate an empty peripheral. Define some regs, RAMs, FIFOs or IRQs, please...");
 end
 end
 function deepcopy(i)
 local o={}
-local function a(e)
+local function t(e)
 if type(e)~="table"then
 return e
 elseif o[e]then
 return o[e]
 end
-local t={}
-o[e]=t
-for e,o in pairs(e)do
-t[a(e)]=a(o)
+local a={}
+o[e]=a
+for o,e in pairs(e)do
+a[t(o)]=t(e)
 end
-return setmetatable(t,getmetatable(e))
+return setmetatable(a,getmetatable(e))
 end
-return a(i)
+return t(i)
 end
-function va(t,a)
+function va(a,t)
 local e={};
 e.t="assign";
-e.dst=t;
-e.src=a;
+e.dst=a;
+e.src=t;
 return e;
 end
-function vi(o,a,t)
+function vi(t,a,o)
 local e={};
 e.t="index";
-e.name=o;
+e.name=t;
 e.h=a;
-e.l=t;
+e.l=o;
 return e;
 end
-function vinstance(t,o,a)
+function vinstance(a,t,o)
 local e={};
 e.t="instance";
-e.name=t;
-e.component=o;
-e.maps=a;
+e.name=a;
+e.component=t;
+e.maps=o;
 return e;
 end
 function vpm(a,t)
@@ -547,19 +560,19 @@ e.slist=t;
 e.code=a;
 return e;
 end
-function vsyncprocess(t,o,a)
+function vsyncprocess(t,a,o)
 local e={};
 e.t="syncprocess";
 e.clk=t;
-e.rst=o;
-e.code=a;
+e.rst=a;
+e.code=o;
 return e;
 end
-function vreset(a,t)
+function vreset(t,a)
 local e={};
 e.t="reset";
-e.level=a;
-e.code=t;
+e.level=t;
+e.code=a;
 return e;
 end
 function vposedge(t)
@@ -568,19 +581,19 @@ e.t="posedge";
 e.code=t;
 return e;
 end
-function vif(t,a,o)
+function vif(a,t,o)
 local e={};
 e.t="if";
-e.cond={t};
-e.code=a;
+e.cond={a};
+e.code=t;
 e.code_else=o;
 return e;
 end
-function vgenerate_if(t,a)
+function vgenerate_if(a,t)
 local e={};
 e.t="generate_if";
-e.cond={t};
-e.code=a;
+e.cond={a};
+e.code=t;
 return e;
 end
 function vequal(a,t)
@@ -590,18 +603,18 @@ e.a=a;
 e.b=t;
 return e;
 end
-function vand(a,t)
+function vand(t,a)
 local e={};
 e.t="and";
-e.a=a;
-e.b=t;
+e.a=t;
+e.b=a;
 return e;
 end
-function vor(a,t)
+function vor(t,a)
 local e={};
 e.t="or";
-e.a=a;
-e.b=t;
+e.a=t;
+e.b=a;
 return e;
 end
 function vnot(t)
@@ -610,11 +623,11 @@ e.t="not";
 e.a=t;
 return e;
 end
-function vswitch(t,a)
+function vswitch(a,t)
 local e={};
 e.t="switch";
-e.a=t;
-e.code=a;
+e.a=a;
+e.code=t;
 return e;
 end
 function vcase(t,a)
@@ -670,13 +683,13 @@ end
 VPORT_WB=1;
 VPORT_REG=2;
 VPORT_CLK_RST=3;
-function port(a,i,o,s,n,t)
+function port(a,o,i,s,n,t)
 local e={}
 e.comment=n;
 e.type=a;
-e.range=i;
+e.range=o;
 e.name=s;
-e.dir=o;
+e.dir=i;
 if(t~=nil)then
 if(t==VPORT_WB)then
 e.is_wb=true;
@@ -736,12 +749,12 @@ end
 function cgen_build_optional_list()
 local o={}
 local a={}
-local t=1
-for i,e in pairs(tree_2_table("optional"))do
-if o[e]==nil then
-o[e]=1
-a[t]=e
-t=t+1
+local e=1
+for i,t in pairs(tree_2_table("optional"))do
+if o[t]==nil then
+o[t]=1
+a[e]=t
+e=e+1
 end
 end
 return a
@@ -849,23 +862,23 @@ function gen_vhdl_bin_literal(i,o)
 if(o==1)then
 return string.format("'%d'",csel(i==0,0,1));
 end
-local e='\"';
-local s,a,n,t;
+local t='\"';
+local s,a,n,e;
 a=i;
-t=math.pow(2,o-1);
+e=math.pow(2,o-1);
 if(i==nil)then
-for t=1,o do
-e=e.."X";
+for e=1,o do
+t=t.."X";
 end
 else
 for o=1,o do
-n=math.floor(a/t);
-e=e..csel(n>0,"1","0");
-a=a%t;
-t=t/2;
+n=math.floor(a/e);
+t=t..csel(n>0,"1","0");
+a=a%e;
+e=e/2;
 end
 end
-return e..'\"';
+return t..'\"';
 end
 function strip_periph_prefix(e)
 return string.gsub(e,"^"..periph.hdl_prefix.."\_","")
@@ -1042,8 +1055,8 @@ emit("use work.wishbone_pkg.all;");
 end
 emit("");
 end
-function cgen_vhdl_interface_declaration(o)
-emit(o.." "..periph.hdl_entity.." is");
+function cgen_vhdl_interface_declaration(a)
+emit(a.." "..periph.hdl_entity.." is");
 indent_right();
 if(table.getn(g_optlist)~=0)then
 emit("generic (");
@@ -1096,7 +1109,7 @@ end
 indent_left();
 emit(");");
 indent_left();
-if(o=="component")then
+if(a=="component")then
 emit("end component;");
 else
 emit("end "..periph.hdl_entity..";");
@@ -1296,16 +1309,16 @@ else
 die("unsupported assignment: "..t.name.." "..e.name);end
 else die("unsupported assignment: "..t.name.." "..e.name);end
 end
-function cgen_vhdl_assign(e)
-local t=node_typesize(e.dst);
-local e=node_typesize(e.src);
-if(e.type==EXPRESSION)then
+function cgen_vhdl_assign(t)
+local e=node_typesize(t.dst);
+local t=node_typesize(t.src);
+if(t.type==EXPRESSION)then
 emiti();
-emitx(gen_subrange(t).." <= ");
-recurse({e.code});
+emitx(gen_subrange(e).." <= ");
+recurse({t.code});
 emitx(";\n");
 else
-emit(gen_subrange(t).." <= "..gen_vhdl_typecvt(t,e)..";");
+emit(gen_subrange(e).." <= "..gen_vhdl_typecvt(e,t)..";");
 end
 end
 function cgen_vhdl_if(e)
@@ -1344,22 +1357,22 @@ else
 emitx(gen_subrange(e));
 end
 end
-function cgen_vhdl_binary_op(e)
-local a=node_typesize(e.a);
-local o=node_typesize(e.b);
-local t=e.t;
+function cgen_vhdl_binary_op(t)
+local a=node_typesize(t.a);
+local o=node_typesize(t.b);
+local e=t.t;
 if(a.type==EXPRESSION)then
-emitx("(");recurse({e.a});emitx(")");
+emitx("(");recurse({t.a});emitx(")");
 else
 emitx(gen_subrange(a));
 end
-if(t=="eq")then emitx(" = ");end
-if(t=="and")then emitx(" and ");end
-if(t=="or")then emitx(" or ");end
-if(t=="sub")then emitx(" - ");end
-if(t=="add")then emitx(" + ");end
+if(e=="eq")then emitx(" = ");end
+if(e=="and")then emitx(" and ");end
+if(e=="or")then emitx(" or ");end
+if(e=="sub")then emitx(" - ");end
+if(e=="add")then emitx(" + ");end
 if(o.type==EXPRESSION)then
-emitx("(");recurse({e.b});emitx(")");
+emitx("(");recurse({t.b});emitx(")");
 else
 emitx(gen_vhdl_typecvt(a,o));
 end
@@ -1564,7 +1577,7 @@ function cgen_verilog_ending()
 indent_left();
 emit("endmodule");
 end
-function cgen_generate_verilog_code(n)
+function cgen_generate_verilog_code(i)
 local a=false;
 function find_code(e,t)
 for a,e in ipairs(e)do if((e.t~=nil)and(e.t==t))then return e;end end
@@ -1721,23 +1734,23 @@ emitx(gen_subrange(e));
 end
 end
 function cgen_verilog_binary_op(t)
-local o=node_typesize(t.a);
-local a=node_typesize(t.b);
+local a=node_typesize(t.a);
+local o=node_typesize(t.b);
 local e=t.t;
-if(o.type==EXPRESSION)then
+if(a.type==EXPRESSION)then
 emitx("(");recurse({t.a});emitx(")");
 else
-emitx(gen_subrange(o));
+emitx(gen_subrange(a));
 end
 if(e=="eq")then emitx(" == ");end
 if(e=="and")then emitx(" && ");end
 if(e=="or")then emitx(" || ");end
 if(e=="sub")then emitx(" - ");end
 if(e=="add")then emitx(" + ");end
-if(a.type==EXPRESSION)then
+if(o.type==EXPRESSION)then
 emitx("(");recurse({t.b});emitx(")");
 else
-emitx(gen_subrange(a));
+emitx(gen_subrange(o));
 end
 end
 function cgen_verilog_comment(e)
@@ -1769,29 +1782,29 @@ end
 end
 emit("endcase");
 end
-function cgen_verilog_instance(a)
+function cgen_verilog_instance(t)
 local o=0;
-local i=0;
+local a=0;
 local e;
-emitx(a.component.." ");
-for t,e in pairs(a.maps)do
+emitx(t.component.." ");
+for t,e in pairs(t.maps)do
 if(e.t=="genmap")then
-i=i+1;
+a=a+1;
 elseif(e.t=="portmap")then
 o=o+1;
 end
 end
-if(i>0)then
+if(a>0)then
 indent_right();
 emit("# (");
 indent_right();
 e=1;
-for t,a in pairs(a.maps)do
-if(a.t=="genmap")then
-local t=a.from;
+for t,o in pairs(t.maps)do
+if(o.t=="genmap")then
+local t=o.from;
 if(t=="true")then t=1;
 elseif(t=="false")then t=0;end
-emit(string.format(".%-20s(%s)",a.to,t)..csel(e==i,"",","));
+emit(string.format(".%-20s(%s)",o.to,t)..csel(e==a,"",","));
 e=e+1;
 end
 end
@@ -1801,10 +1814,10 @@ indent_left();
 end
 if(o>0)then
 indent_right();
-emit(a.name.." ( ");
+emit(t.name.." ( ");
 indent_right();
 e=1;
-for a,t in pairs(a.maps)do
+for a,t in pairs(t.maps)do
 if(t.t=="portmap")then
 local a=node_typesize(t.from);
 emit(string.format(".%-20s(%s)",t.to,gen_subrange(a))..csel(e==o,"",","));
@@ -1874,17 +1887,17 @@ end
 end
 cgen_new_snippet();
 cgen_verilog_header();
-local a=cgen_get_snippet();
-cgen_new_snippet();
-recurse(n);
-cgen_verilog_ending();
 local e=cgen_get_snippet();
+cgen_new_snippet();
+recurse(i);
+cgen_verilog_ending();
+local a=cgen_get_snippet();
 cgen_new_snippet();
 cgen_verilog_module();
 local t=cgen_get_snippet();
-cgen_write_snippet(a);
-cgen_write_snippet(t);
 cgen_write_snippet(e);
+cgen_write_snippet(t);
+cgen_write_snippet(a);
 end
 function cgen_c_field_define(e,a)
 local t;
@@ -1921,7 +1934,7 @@ dbg("DOCREG: ",e.name,e.num_fields);
 if(e.num_fields~=nil and e.num_fields>0)then
 emit("");
 emit("/* definitions for register: "..e.name.." */");
-foreach_subfield(e,function(t,e)cgen_c_field_define(t,e)end);
+foreach_subfield(e,function(e,t)cgen_c_field_define(e,t)end);
 end
 end);
 foreach_reg({TYPE_RAM},function(e)
@@ -2069,20 +2082,20 @@ end
 end
 return e;
 end
-function htable_tdstyle(a,t,e)
-tbl.data[a][t].style=e;
+function htable_tdstyle(e,a,t)
+tbl.data[e][a].style=t;
 end
-function htable_trstyle(e,a,t)
-tbl.data[e].style=t;
+function htable_trstyle(t,a,e)
+tbl.data[t].style=e;
 end
-function htable_frame(e,t,o,a)
-if(a==nil)then
-e.data[t][o].extra='style="border: solid 1px black;"';
+function htable_frame(e,t,a,o)
+if(o==nil)then
+e.data[t][a].extra='style="border: solid 1px black;"';
 else
-e.data[t][o].extra='style="border-left: solid 1px black; border-top: solid 1px black; border-bottom: solid 1px black;';
-e.data[t][a].extra='style="border-right: solid 1px black; border-top: solid 1px black; border-bottom: solid 1px black;';
-if(a>o+1)then
-for a=o+1,a-1 do
+e.data[t][a].extra='style="border-left: solid 1px black; border-top: solid 1px black; border-bottom: solid 1px black;';
+e.data[t][o].extra='style="border-right: solid 1px black; border-top: solid 1px black; border-bottom: solid 1px black;';
+if(o>a+1)then
+for a=a+1,o-1 do
 e.data[t][a].extra='border-top: solid 1px black; border-bottom: solid 1px black;';
 end
 end
@@ -2121,11 +2134,11 @@ emit("</tr>");
 end
 emit("</table>");
 end
-function has_any_ports(t)
-local e=false;
-if(t.ports~=nil)then return true;end
-foreach_subfield(t,function(t)if(t.ports~=nil)then e=true;end end);
-return e;
+function has_any_ports(e)
+local t=false;
+if(e.ports~=nil)then return true;end
+foreach_subfield(e,function(e)if(e.ports~=nil)then t=true;end end);
+return t;
 end
 function htable_add_row(e,t)
 if(t>e.rows)then
@@ -2149,17 +2162,17 @@ function hanchor(e,t)
 return'<a name="'..e..'">'..t..'</a>';
 end
 doc_toc={};
-function hsection(a,t,o)
+function hsection(t,a,o)
 local e={};
 local i=0;
-e.id_mangled="sect_"..a.."_"..t;
-e.key=a*1e3+t;
-if(t~=0)then
+e.id_mangled="sect_"..t.."_"..a;
+e.key=t*1e3+a;
+if(a~=0)then
 e.level=2;
-e.id=a.."."..t..".";
+e.id=t.."."..a..".";
 else
 e.level=1;
-e.id=a..".";
+e.id=t..".";
 end
 e.name=o;
 table.insert(doc_toc,e);
@@ -2226,26 +2239,26 @@ table.insert(t,e);
 end
 cgen_doc_symbol(t);
 end
-function cgen_doc_symbol(o)
+function cgen_doc_symbol(i)
 local t=htable_new(3,5);
 local a=1;
 local e=1;
-local i=true;
-for o,e in pairs(o)do
+local o=true;
+for o,e in pairs(i)do
 if(e.is_wb)then
 htable_add_row(t,a);
 cgen_doc_port(t.data[a],e,true);
 a=a+1;
 end
 end
-for o,a in ipairs(o)do
+for i,a in ipairs(i)do
 if(type(a)=="string")then
-if(i==false)then
+if(o==false)then
 htable_add_row(t,e);
 row=t.data[e];row[3].text="&nbsp;";
 e=e+1;
 else
-i=false;
+o=false;
 end
 htable_add_row(t,e);
 local t=t.data[e];
@@ -2291,11 +2304,11 @@ emit('<span style="margin-left: '..((e.level-1)*20)..'px; ">'..e.id.." "..hlink(
 end
 end
 function cgen_doc_memmap()
-local i=0;
+local o=0;
 local a=2;
 emit(hsection(1,0,"Memory map summary"));
-local o=htable_new(1,5);
-local e=o.data[1];
+local i=htable_new(1,5);
+local e=i.data[1];
 e.is_header=true;
 e[1].text="H/W Address"
 e[2].text="Type";
@@ -2304,9 +2317,9 @@ e[4].text="VHDL/Verilog prefix";
 e[5].text="C prefix";
 foreach_reg({TYPE_REG},function(t)
 if(t.full_hdl_prefix~=nil)then
-htable_add_row(o,a);
-local e=o.data[a];a=a+1;
-e.style=csel(i,"tr_odd","tr_even");
+htable_add_row(i,a);
+local e=i.data[a];a=a+1;
+e.style=csel(o,"tr_odd","tr_even");
 e[1].style="td_code";
 e[1].text=string.format("0x%x",t.base);
 if(t.doc_is_fiforeg==nil)then
@@ -2319,14 +2332,14 @@ e[4].style="td_code";
 e[4].text=t.full_hdl_prefix;
 e[5].style="td_code";
 e[5].text=string.upper(t.c_prefix);
-i=not i;
+o=not o;
 end
 end);
 foreach_reg({TYPE_RAM},function(e)
 if(e.full_hdl_prefix~=nil)then
-htable_add_row(o,a);
-local t=o.data[a];a=a+1;
-t.style=csel(i,"tr_odd","tr_even");
+htable_add_row(i,a);
+local t=i.data[a];a=a+1;
+t.style=csel(o,"tr_odd","tr_even");
 t[1].style="td_code";
 t[1].text=string.format("0x%x - 0x%x",e.base,e.base+math.pow(2,e.wrap_bits)*e.size-1);
 t[2].text="MEM";
@@ -2335,32 +2348,32 @@ t[4].style="td_code";
 t[4].text=e.full_hdl_prefix;
 t[5].style="td_code";
 t[5].text=string.upper(e.c_prefix);
-i=not i;
+o=not o;
 end
 end);
-htable_emit(o);
+htable_emit(i);
 end
-function find_field_by_offset(e,a)
-local t=nil;
-foreach_subfield(e,function(e)if(a>=e.offset and a<=(e.offset+e.size-1))then t=e;end end);
-return t;
+function find_field_by_offset(e,t)
+local a=nil;
+foreach_subfield(e,function(e)if(t>=e.offset and t<=(e.offset+e.size-1))then a=e;end end);
+return a;
 end
 function cgen_doc_fieldtable(h,i)
 local e=70;
-local t;
-local e=1;
-t=htable_new(2,8);
-for e=1,8 do
-t.data[1][e].style="td_bit";
-t.data[1][e].text=string.format("%d",i+8-e);
+local e;
+local t=1;
+e=htable_new(2,8);
+for t=1,8 do
+e.data[1][t].style="td_bit";
+e.data[1][t].text=string.format("%d",i+8-t);
 end
 local a=i+7;
 while(a>=i)do
 local o=find_field_by_offset(h,a);
 if(o==nil)then
-t.data[2][e].style="td_unused";
-t.data[2][e].text="-";
-e=e+1;
+e.data[2][t].style="td_unused";
+e.data[2][t].text="-";
+t=t+1;
 a=a-1;
 else
 local n;
@@ -2371,18 +2384,18 @@ n=o.offset;
 end
 local s=(a-n)+1;
 dbg("ncells: ",s,"bit: ",a,"name: ",o.prefix);
-t.data[2][e].colspan=s;
+e.data[2][t].colspan=s;
 local i;
 i=o.c_prefix;
 if(i==nil)then i=h.c_prefix;end
-t.data[2][e].style="td_field";
-t.data[2][e].text=csel(o.size>1,string.format("%s[%d:%d]",string.upper(i),a-o.offset,n-o.offset),string.upper(i));
-htable_frame(t,2,e);
+e.data[2][t].style="td_field";
+e.data[2][t].text=csel(o.size>1,string.format("%s[%d:%d]",string.upper(i),a-o.offset,n-o.offset),string.upper(i));
+htable_frame(e,2,t);
 a=a-s;
-e=e+1;
+t=t+1;
 end
 end
-htable_emit(t);
+htable_emit(e);
 end
 function cgen_doc_access(e)
 if(e==READ_ONLY)then
@@ -2505,24 +2518,24 @@ emit("<p>"..string.gsub(t.description,"\n","<br>").."</p>");
 end
 end
 function cgen_generate_html_documentation()
-cgen_new_snippet();cgen_doc_hdl_symbol();local o=cgen_get_snippet();
+cgen_new_snippet();cgen_doc_hdl_symbol();local i=cgen_get_snippet();
 cgen_new_snippet();
 emit(hsection(3,0,"Register description"));
 foreach_reg({TYPE_REG},function(e)if(e.no_docu==nil or e.no_docu==false)then cgen_doc_reg(e);end end);
-local i=cgen_get_snippet();
-local t="";
+local o=cgen_get_snippet();
+local a="";
 if(periph.ramcount>0)then
 emit(hsection(4,0,"Memory blocks"));
 cgen_new_snippet();
 foreach_reg({TYPE_RAM},function(e)if(e.no_docu==nil or e.no_docu==false)then cgen_doc_ram(e);end end);
-t=cgen_get_snippet();
+a=cgen_get_snippet();
 end
-local a="";
+local t="";
 if(periph.irqcount>0)then
 cgen_new_snippet();
 emit(hsection(5,0,"Interrupts"));
 foreach_reg({TYPE_IRQ},function(e)if(e.no_docu==nil or e.no_docu==false)then cgen_doc_irq(e);end end);
-a=cgen_get_snippet();
+t=cgen_get_snippet();
 end
 cgen_new_snippet();
 cgen_doc_memmap();
@@ -2530,10 +2543,10 @@ local e=cgen_get_snippet();
 cgen_new_snippet();
 cgen_doc_header_and_toc();
 emit(e);
-emit(o);
 emit(i);
-emit(t);
+emit(o);
 emit(a);
+emit(t);
 emit('</BODY>');
 emit('</HTML>');
 cgen_write_current_snippet();
@@ -2952,19 +2965,19 @@ cgen_new_snippet();
 emit("\\subsubsection{Register description}");
 foreach_reg({TYPE_REG},function(e)if(e.no_docu==nil or e.no_docu==false)then cgen_doc_lx_reg(e);end end);
 local o=cgen_get_snippet();
-local a="";
+local t="";
 if(periph.ramcount>0)then
 emit("\\subsubsection{Memory blocks}");
 cgen_new_snippet();
 foreach_reg({TYPE_RAM},function(e)if(e.no_docu==nil or e.no_docu==false)then cgen_doc_lx_ram(e);end end);
-a=cgen_get_snippet();
+t=cgen_get_snippet();
 end
-local t="";
+local a="";
 if(periph.irqcount>0)then
 cgen_new_snippet();
 emit("\\subsubsection{Interrupts}");
 foreach_reg({TYPE_IRQ},function(e)if(e.no_docu==nil or e.no_docu==false)then cgen_doc_lx_irq(e);end end);
-t=cgen_get_snippet();
+a=cgen_get_snippet();
 end
 cgen_new_snippet();
 cgen_doc_lx_memmap();
@@ -2973,8 +2986,8 @@ cgen_new_snippet();
 cgen_doc_lx_header_and_toc();
 emit(e);
 emit(o);
-emit(a);
 emit(t);
+emit(a);
 cgen_write_current_snippet();
 end
 function gen_hdl_field_prefix(a,e)
@@ -3050,163 +3063,163 @@ t.ackgen_code_pre={va(e.."_int",e.."_int_delay");
 va(e.."_int_delay",0);};
 end
 end
-function gen_hdl_code_bit(e,a)
-local t=gen_hdl_field_prefix(e,a);
-e.prefix=t;
-if(e.clock==nil)then
-if(e.access==ACC_RW_RO)then
-e.ports={port(BIT,0,"out",t.."_o","Port for BIT field: '"..e.name.."' in reg: '"..a.name.."'",VPORT_REG)};
-e.signals={signal(BIT,0,t.."_int")};
-e.acklen=1;
-e.write_code={
-va(t.."_int",vi("wrdata_reg",e.offset))};
-e.read_code={va(vi("rddata_reg",e.offset),t.."_int")};
-e.reset_code_main={va(t.."_int",csel(e.reset_value==nil,0,e.reset_value))};
-e.extra_code={va(t.."_o",t.."_int")};
-elseif(e.access==ACC_RO_WO)then
-e.ports={port(BIT,0,"in",t.."_i","Port for BIT field: '"..e.name.."' in reg: '"..a.name.."'",VPORT_REG)};
-e.signals={};
-e.acklen=1;
-e.write_code={};
-e.read_code={va(vi("rddata_reg",e.offset),t.."_i")};
-e.reset_code_main={};
-e.extra_code={};
-elseif(e.access==ACC_WO_RO)then
-die("WO-RO type unsupported yet ("..e.name..")");
-elseif(e.access==ACC_RW_RW)then
-if(e.load==LOAD_EXT)then
-e.ports={port(BIT,0,"out",t.."_o","Ports for BIT field: '"..e.name.."' in reg: '"..a.name.."'",VPORT_REG),
-port(BIT,0,"in",t.."_i",nil,VPORT_REG),
-port(BIT,0,"out",t.."_load_o",nil,VPORT_REG)};
-e.acklen=1;
-e.read_code={va(vi("rddata_reg",e.offset),t.."_i")};
-e.write_code={
-va(t.."_load_o",1)};
-e.extra_code={va(t.."_o",vi("wrdata_reg",e.offset))};
-e.ackgen_code_pre={va(t.."_load_o",0)};
-e.ackgen_code={va(t.."_load_o",0)};
-e.reset_code_main={va(t.."_load_o",0)};
+function gen_hdl_code_bit(t,a)
+local e=gen_hdl_field_prefix(t,a);
+t.prefix=e;
+if(t.clock==nil)then
+if(t.access==ACC_RW_RO)then
+t.ports={port(BIT,0,"out",e.."_o","Port for BIT field: '"..t.name.."' in reg: '"..a.name.."'",VPORT_REG)};
+t.signals={signal(BIT,0,e.."_int")};
+t.acklen=1;
+t.write_code={
+va(e.."_int",vi("wrdata_reg",t.offset))};
+t.read_code={va(vi("rddata_reg",t.offset),e.."_int")};
+t.reset_code_main={va(e.."_int",csel(t.reset_value==nil,0,t.reset_value))};
+t.extra_code={va(e.."_o",e.."_int")};
+elseif(t.access==ACC_RO_WO)then
+t.ports={port(BIT,0,"in",e.."_i","Port for BIT field: '"..t.name.."' in reg: '"..a.name.."'",VPORT_REG)};
+t.signals={};
+t.acklen=1;
+t.write_code={};
+t.read_code={va(vi("rddata_reg",t.offset),e.."_i")};
+t.reset_code_main={};
+t.extra_code={};
+elseif(t.access==ACC_WO_RO)then
+die("WO-RO type unsupported yet ("..t.name..")");
+elseif(t.access==ACC_RW_RW)then
+if(t.load==LOAD_EXT)then
+t.ports={port(BIT,0,"out",e.."_o","Ports for BIT field: '"..t.name.."' in reg: '"..a.name.."'",VPORT_REG),
+port(BIT,0,"in",e.."_i",nil,VPORT_REG),
+port(BIT,0,"out",e.."_load_o",nil,VPORT_REG)};
+t.acklen=1;
+t.read_code={va(vi("rddata_reg",t.offset),e.."_i")};
+t.write_code={
+va(e.."_load_o",1)};
+t.extra_code={va(e.."_o",vi("wrdata_reg",t.offset))};
+t.ackgen_code_pre={va(e.."_load_o",0)};
+t.ackgen_code={va(e.."_load_o",0)};
+t.reset_code_main={va(e.."_load_o",0)};
 else
-die("internal RW/RW register storage unsupported yet ("..e.name..")");
+die("internal RW/RW register storage unsupported yet ("..t.name..")");
 end
 end
 else
-if(e.access==ACC_RW_RO)then
-e.ports={port(BIT,0,"out",t.."_o","Port for asynchronous (clock: "..e.clock..") BIT field: '"..e.name.."' in reg: '"..a.name.."'",VPORT_REG)};
-e.signals={signal(BIT,0,t.."_int"),
-signal(BIT,0,t.."_sync0"),
-signal(BIT,0,t.."_sync1")};
-e.acklen=4;
-e.write_code={va(t.."_int",vi("wrdata_reg",e.offset))};
-e.read_code={va(vi("rddata_reg",e.offset),t.."_int")};
-e.reset_code_main={va(t.."_int",csel(e.reset_value==nil,0,e.reset_value))};
-e.extra_code={vcomment("synchronizer chain for field : "..e.name.." (type RW/RO, clk_sys_i <-> "..e.clock..")");
-vsyncprocess(e.clock,"rst_n_i",{
+if(t.access==ACC_RW_RO)then
+t.ports={port(BIT,0,"out",e.."_o","Port for asynchronous (clock: "..t.clock..") BIT field: '"..t.name.."' in reg: '"..a.name.."'",VPORT_REG)};
+t.signals={signal(BIT,0,e.."_int"),
+signal(BIT,0,e.."_sync0"),
+signal(BIT,0,e.."_sync1")};
+t.acklen=4;
+t.write_code={va(e.."_int",vi("wrdata_reg",t.offset))};
+t.read_code={va(vi("rddata_reg",t.offset),e.."_int")};
+t.reset_code_main={va(e.."_int",csel(t.reset_value==nil,0,t.reset_value))};
+t.extra_code={vcomment("synchronizer chain for field : "..t.name.." (type RW/RO, clk_sys_i <-> "..t.clock..")");
+vsyncprocess(t.clock,"rst_n_i",{
 vreset(0,{
-va(t.."_o",csel(e.reset_value==nil,0,e.reset_value));
-va(t.."_sync0",csel(e.reset_value==nil,0,e.reset_value));
-va(t.."_sync1",csel(e.reset_value==nil,0,e.reset_value));
+va(e.."_o",csel(t.reset_value==nil,0,t.reset_value));
+va(e.."_sync0",csel(t.reset_value==nil,0,t.reset_value));
+va(e.."_sync1",csel(t.reset_value==nil,0,t.reset_value));
 });
 vposedge({
-va(t.."_sync0",t.."_int");
-va(t.."_sync1",t.."_sync0");
-va(t.."_o",t.."_sync1");
+va(e.."_sync0",e.."_int");
+va(e.."_sync1",e.."_sync0");
+va(e.."_o",e.."_sync1");
 });
 });
 };
-elseif(e.access==ACC_RO_WO)then
-e.ports={port(BIT,0,"in",t.."_i","Port for asynchronous (clock: "..e.clock..") BIT field: '"..e.name.."' in reg: '"..a.name.."'",VPORT_REG)};
-e.signals={signal(BIT,0,t.."_sync0"),
-signal(BIT,0,t.."_sync1")};
-e.acklen=1;
-e.write_code={};
-e.read_code={va(vi("rddata_reg",e.offset),t.."_sync1")};
-e.reset_code_main={};
-e.extra_code={vcomment("synchronizer chain for field : "..e.name.." (type RO/WO, "..e.clock.." -> clk_sys_i)");
-vsyncprocess(e.clock,"rst_n_i",{
+elseif(t.access==ACC_RO_WO)then
+t.ports={port(BIT,0,"in",e.."_i","Port for asynchronous (clock: "..t.clock..") BIT field: '"..t.name.."' in reg: '"..a.name.."'",VPORT_REG)};
+t.signals={signal(BIT,0,e.."_sync0"),
+signal(BIT,0,e.."_sync1")};
+t.acklen=1;
+t.write_code={};
+t.read_code={va(vi("rddata_reg",t.offset),e.."_sync1")};
+t.reset_code_main={};
+t.extra_code={vcomment("synchronizer chain for field : "..t.name.." (type RO/WO, "..t.clock.." -> clk_sys_i)");
+vsyncprocess(t.clock,"rst_n_i",{
 vreset(0,{
-va(t.."_sync0",0);
-va(t.."_sync1",0);
+va(e.."_sync0",0);
+va(e.."_sync1",0);
 });
 vposedge({
-va(t.."_sync0",t.."_i");
-va(t.."_sync1",t.."_sync0");
+va(e.."_sync0",e.."_i");
+va(e.."_sync1",e.."_sync0");
 });
 });
 };
-elseif(e.access==ACC_RW_RW)then
-if(e.load~=LOAD_EXT)then
+elseif(t.access==ACC_RW_RW)then
+if(t.load~=LOAD_EXT)then
 die("Only external load is supported for RW/RW bit fields");
 end
-local a="Ports for asynchronous (clock: "..e.clock..") RW/RW BIT field: '"..e.name.."' in reg: '"..a.name.."'";
-e.ports={port(BIT,0,"out",t.."_o",a,VPORT_REG),
-port(BIT,0,"in",t.."_i",nil,VPORT_REG),
-port(BIT,0,"out",t.."_load_o",nil,VPORT_REG)};
-e.signals={signal(BIT,0,t.."_int_read"),
-signal(BIT,0,t.."_int_write"),
-signal(BIT,0,t.."_lw"),
-signal(BIT,0,t.."_lw_delay"),
-signal(BIT,0,t.."_lw_read_in_progress"),
-signal(BIT,0,t.."_lw_s0"),
-signal(BIT,0,t.."_lw_s1"),
-signal(BIT,0,t.."_lw_s2"),
-signal(BIT,0,t.."_rwsel")};
-e.acklen=6;
-e.write_code={
-va(t.."_int_write",vi("wrdata_reg",e.offset));
-va(t.."_lw",1);
-va(t.."_lw_delay",1);
-va(t.."_lw_read_in_progress",0);
-va(t.."_rwsel",1);};
-e.read_code={vif(vequal("wb_we_i",0),{
-va(vi("rddata_reg",e.offset),vundefined());
-va(t.."_lw",1);
-va(t.."_lw_delay",1);
-va(t.."_lw_read_in_progress",1);
-va(t.."_rwsel",0);});};
-e.reset_code_main={va(t.."_lw",0);
-va(t.."_lw_delay",0);
-va(t.."_lw_read_in_progress",0);
-va(t.."_rwsel",0);
-va(t.."_int_write",0);
+local a="Ports for asynchronous (clock: "..t.clock..") RW/RW BIT field: '"..t.name.."' in reg: '"..a.name.."'";
+t.ports={port(BIT,0,"out",e.."_o",a,VPORT_REG),
+port(BIT,0,"in",e.."_i",nil,VPORT_REG),
+port(BIT,0,"out",e.."_load_o",nil,VPORT_REG)};
+t.signals={signal(BIT,0,e.."_int_read"),
+signal(BIT,0,e.."_int_write"),
+signal(BIT,0,e.."_lw"),
+signal(BIT,0,e.."_lw_delay"),
+signal(BIT,0,e.."_lw_read_in_progress"),
+signal(BIT,0,e.."_lw_s0"),
+signal(BIT,0,e.."_lw_s1"),
+signal(BIT,0,e.."_lw_s2"),
+signal(BIT,0,e.."_rwsel")};
+t.acklen=6;
+t.write_code={
+va(e.."_int_write",vi("wrdata_reg",t.offset));
+va(e.."_lw",1);
+va(e.."_lw_delay",1);
+va(e.."_lw_read_in_progress",0);
+va(e.."_rwsel",1);};
+t.read_code={vif(vequal("wb_we_i",0),{
+va(vi("rddata_reg",t.offset),vundefined());
+va(e.."_lw",1);
+va(e.."_lw_delay",1);
+va(e.."_lw_read_in_progress",1);
+va(e.."_rwsel",0);});};
+t.reset_code_main={va(e.."_lw",0);
+va(e.."_lw_delay",0);
+va(e.."_lw_read_in_progress",0);
+va(e.."_rwsel",0);
+va(e.."_int_write",0);
 };
-e.ackgen_code_pre={va(t.."_lw",t.."_lw_delay");
-va(t.."_lw_delay",0);
-vif(vand(vequal(vi("ack_sreg",1),1),vequal(t.."_lw_read_in_progress",1)),{
-va(vi("rddata_reg",e.offset),t.."_int_read");
-va(t.."_lw_read_in_progress",0);
+t.ackgen_code_pre={va(e.."_lw",e.."_lw_delay");
+va(e.."_lw_delay",0);
+vif(vand(vequal(vi("ack_sreg",1),1),vequal(e.."_lw_read_in_progress",1)),{
+va(vi("rddata_reg",t.offset),e.."_int_read");
+va(e.."_lw_read_in_progress",0);
 });
 };
-e.extra_code={vcomment("asynchronous BIT register : "..e.name.." (type RW/WO, "..e.clock.." <-> clk_sys_i)");
-vsyncprocess(e.clock,"rst_n_i",{
+t.extra_code={vcomment("asynchronous BIT register : "..t.name.." (type RW/WO, "..t.clock.." <-> clk_sys_i)");
+vsyncprocess(t.clock,"rst_n_i",{
 vreset(0,{
-va(t.."_lw_s0",0);
-va(t.."_lw_s1",0);
-va(t.."_lw_s2",0);
-va(t.."_int_read",0);
-va(t.."_load_o",0);
-va(t.."_o",0);
+va(e.."_lw_s0",0);
+va(e.."_lw_s1",0);
+va(e.."_lw_s2",0);
+va(e.."_int_read",0);
+va(e.."_load_o",0);
+va(e.."_o",0);
 });
 vposedge({
-va(t.."_lw_s0",t.."_lw");
-va(t.."_lw_s1",t.."_lw_s0");
-va(t.."_lw_s2",t.."_lw_s1");
-vif(vand(vequal(t.."_lw_s2",0),vequal(t.."_lw_s1",1)),{
-vif(vequal(t.."_rwsel",1),{
-va(t.."_o",t.."_int_write");
-va(t.."_load_o",1);
+va(e.."_lw_s0",e.."_lw");
+va(e.."_lw_s1",e.."_lw_s0");
+va(e.."_lw_s2",e.."_lw_s1");
+vif(vand(vequal(e.."_lw_s2",0),vequal(e.."_lw_s1",1)),{
+vif(vequal(e.."_rwsel",1),{
+va(e.."_o",e.."_int_write");
+va(e.."_load_o",1);
 },{
-va(t.."_load_o",0);
-va(t.."_int_read",t.."_i");
+va(e.."_load_o",0);
+va(e.."_int_read",e.."_i");
 });
 },{
-va(t.."_load_o",0);
+va(e.."_load_o",0);
 });
 });
 });
 };
-elseif(e.access==ACC_WO_RO)then
-die("WO-RO type unsupported yet ("..e.name..")");
+elseif(t.access==ACC_WO_RO)then
+die("WO-RO type unsupported yet ("..t.name..")");
 end
 end
 end
@@ -3616,8 +3629,8 @@ end
 function wbgen_generate_eic()
 if(periph.irqcount==0)then return;end
 local t=0;
-local s={};
-local i={["__type"]=TYPE_REG;
+local n={};
+local s={["__type"]=TYPE_REG;
 ["__blockindex"]=1e6;
 ["align"]=8;
 ["name"]="Interrupt disable register";
@@ -3633,7 +3646,7 @@ signal(BIT,0,"eic_idr_write_int");};
 ["extra_code"]={va(vi("eic_idr_int",periph.irqcount-1,0),vi("wrdata_reg",periph.irqcount-1,0));};
 ["no_std_regbank"]=true;
 };
-local n={["__type"]=TYPE_REG;
+local a={["__type"]=TYPE_REG;
 ["__blockindex"]=1000001;
 ["align"]=1;
 ["name"]="Interrupt enable register";
@@ -3668,7 +3681,7 @@ signal(BIT,0,"eic_isr_write_int");};
 ["extra_code"]={va(vi("eic_isr_clear_int",periph.irqcount-1,0),vi("wrdata_reg",periph.irqcount-1,0));};
 ["no_std_regbank"]=true;
 };
-local a={["__type"]=TYPE_REG;
+local i={["__type"]=TYPE_REG;
 ["__blockindex"]=1000003;
 ["align"]=1;
 ["name"]="Interrupt mask register";
@@ -3683,7 +3696,7 @@ local a={["__type"]=TYPE_REG;
 foreach_reg({TYPE_IRQ},function(e)
 e.index=t;
 t=t+1;
-table.insert(s,{["index"]=e.index;["trigger"]=e.trigger;});
+table.insert(n,{["index"]=e.index;["trigger"]=e.trigger;});
 fix_prefix(e);
 local t={
 ["__blockindex"]=e.index;
@@ -3696,7 +3709,7 @@ local t={
 ["access_bus"]=READ_WRITE;
 ["access_dev"]=READ_WRITE;
 };
-local s={
+local n={
 ["__blockindex"]=e.index;
 ["__type"]=TYPE_FIELD;
 ["type"]=BIT;
@@ -3707,7 +3720,7 @@ local s={
 ["access_bus"]=WRITE_ONLY;
 ["access_dev"]=READ_ONLY;
 };
-local h={
+local r={
 ["__blockindex"]=e.index;
 ["__type"]=TYPE_FIELD;
 ["type"]=BIT;
@@ -3718,7 +3731,7 @@ local h={
 ["access_bus"]=WRITE_ONLY;
 ["access_dev"]=READ_ONLY;
 };
-local r={
+local h={
 ["__blockindex"]=e.index;
 ["__type"]=TYPE_FIELD;
 ["type"]=BIT;
@@ -3738,17 +3751,17 @@ end
 if(e.mask_line==true)then
 table_join(e.ports,{port(BIT,0,"out",e.full_prefix.."_mask_o");});
 end
-table.insert(i,h);
+table.insert(s,r);
 table.insert(o,t);
-table.insert(a,r);
-table.insert(n,s);
+table.insert(i,h);
+table.insert(a,n);
 end);
 add_global_signals({
 signal(SLV,periph.irqcount,"irq_inputs_vector_int");
 });
-table.insert(periph,i);
-table.insert(periph,n);
+table.insert(periph,s);
 table.insert(periph,a);
+table.insert(periph,i);
 table.insert(periph,o);
 local e={vgm("g_num_interrupts",periph.irqcount);
 vpm("clk_i","clk_sys_i");
@@ -3766,7 +3779,7 @@ vpm("reg_isr_wr_stb_i","eic_isr_write_int");
 vpm("wb_irq_o","wb_int_o");
 };
 local a;
-for o,t in ipairs(s)do
+for o,t in ipairs(n)do
 table_join(e,{vgm(string.format("g_irq%02x_mode",t.index),t.trigger)});
 a=o;
 end
@@ -4157,38 +4170,38 @@ gen_pipelined_wb_signals(e);
 foreach_reg(ALL_REG_TYPES,function(e)
 gen_abstract_code(e);
 end);
+local o={};
 local i={};
 local n={};
-local o={};
 foreach_field(function(e,t)
-table_join(i,e.reset_code_main);
+table_join(o,e.reset_code_main);
 end);
 foreach_reg(ALL_REG_TYPES,function(e)
-table_join(i,e.reset_code_main);
+table_join(o,e.reset_code_main);
 end);
 foreach_reg({TYPE_REG},function(e)
 foreach_subfield(e,function(e,t)
-table_join(n,e.ackgen_code);
-table_join(o,e.ackgen_code_pre);
+table_join(i,e.ackgen_code);
+table_join(n,e.ackgen_code_pre);
 end);
-table_join(n,e.ackgen_code);
-table_join(o,e.ackgen_code_pre);
+table_join(i,e.ackgen_code);
+table_join(n,e.ackgen_code_pre);
 end);
 local e={};
 foreach_reg({TYPE_REG},function(t)
 local i=find_max(t,"acklen");
-local o={};
 local a={};
-foreach_subfield(t,function(e,t)table_join(a,e.write_code);end);
-foreach_subfield(t,function(e,t)table_join(o,e.read_code);end);
+local o={};
+foreach_subfield(t,function(e,t)table_join(o,e.write_code);end);
+foreach_subfield(t,function(e,t)table_join(a,e.read_code);end);
 local n=fill_unused_bits("rddata_reg",t,options.unused_zeroes);
-table_join(a,t.write_code);
-table_join(o,t.read_code);
+table_join(o,t.write_code);
+table_join(a,t.read_code);
 local a={
 vif(vequal("wb_we_i",1),{
-a,
-});
 o,
+});
+a,
 n
 };
 if(not(t.dont_emit_ack_code==true))then
@@ -4244,14 +4257,14 @@ vreset(0,{
 va("ack_sreg",0);
 va("ack_in_progress",0);
 va("rddata_reg",0);
-i
+o
 });
 vposedge({
 vcomment("advance the ACK generator shift register");
 va(vi("ack_sreg",MAX_ACK_LENGTH-2,0),vi("ack_sreg",MAX_ACK_LENGTH-1,1));
 va(vi("ack_sreg",MAX_ACK_LENGTH-1),0);
 vif(vequal("ack_in_progress",1),{
-vif(vequal(vi("ack_sreg",0),1),{n;va("ack_in_progress",0);},o);
+vif(vequal(vi("ack_sreg",0),1),{i;va("ack_in_progress",0);},n);
 },{
 e
 });
@@ -4385,7 +4398,7 @@ function usage_complete()
 print(e)
 print(t)
 end
-function parse_args(a)
+function parse_args(o)
 local t={
 help="h",
 version="v",
@@ -4401,8 +4414,8 @@ zeroes="Z",
 hstyle="H"
 }
 local e
-local o
-e,o=alt_getopt.get_opts(a,"hvC:D:K:l:V:s:f:H:p:Z",t)
+local a
+e,a=alt_getopt.get_opts(o,"hvC:D:K:l:V:s:f:H:p:Z",t)
 for t,e in pairs(e)do
 if t=="h"then
 usage_complete()
@@ -4441,11 +4454,11 @@ end
 options.hdl_reg_style=e
 end
 end
-if(a[o]==nil)then
+if(o[a]==nil)then
 usage()
 os.exit(0)
 end
-input_wb_file=a[o];
+input_wb_file=o[a];
 end
 parse_args(arg);
 dofile(input_wb_file);
@@ -4475,6 +4488,8 @@ foreach_reg(ALL_REG_TYPES,fix_prefix);
 foreach_reg(ALL_REG_TYPES,check_obj_names_prefixes);
 foreach_field(check_obj_names_prefixes);
 periph=fix_prefix(periph);
+periph=default_wishbone_width(periph);
+print(periph.wishbone_width);
 wbgen_count_subblocks();
 wbgen_generate_eic();
 foreach_reg(ALL_REG_TYPES,fix_prefix);

--- a/wbgen2
+++ b/wbgen2
@@ -116,7 +116,7 @@ return e,i
 end
 end)
 VERBOSE_DEBUG=0;
-DATA_BUS_WIDTH=32;
+DATA_BUS_WIDTH=nil;
 SYNC_CHAIN_LENGTH=3;
 TYPE_PERIPH=1;
 TYPE_REG=2;
@@ -335,6 +335,9 @@ end
 else
 e.wishbone_width=32;
 end
+e.width=e.wishbone_width;
+DATA_BUS_WIDTH=e.wishbone_width;
+print("DATA_BUS_WIDTH = "..DATA_BUS_WIDTH);
 return e;
 end
 function default_access(e,o,a,t)
@@ -862,23 +865,23 @@ function gen_vhdl_bin_literal(i,o)
 if(o==1)then
 return string.format("'%d'",csel(i==0,0,1));
 end
-local t='\"';
-local s,a,n,e;
+local e='\"';
+local s,a,n,t;
 a=i;
-e=math.pow(2,o-1);
+t=math.pow(2,o-1);
 if(i==nil)then
-for e=1,o do
-t=t.."X";
+for t=1,o do
+e=e.."X";
 end
 else
 for o=1,o do
-n=math.floor(a/e);
-t=t..csel(n>0,"1","0");
-a=a%e;
-e=e/2;
+n=math.floor(a/t);
+e=e..csel(n>0,"1","0");
+a=a%t;
+t=t/2;
 end
 end
-return t..'\"';
+return e..'\"';
 end
 function strip_periph_prefix(e)
 return string.gsub(e,"^"..periph.hdl_prefix.."\_","")
@@ -1407,25 +1410,25 @@ end
 emit("end case;");
 end
 function cgen_vhdl_instance(t)
-local o=0;
 local a=0;
+local o=0;
 local e;
 emit(t.name.." : "..t.component);
 for t,e in pairs(t.maps)do
 if(e.t=="genmap")then
-a=a+1;
-elseif(e.t=="portmap")then
 o=o+1;
+elseif(e.t=="portmap")then
+a=a+1;
 end
 end
-if(a>0)then
+if(o>0)then
 indent_right();
 emit("generic map (");
 indent_right();
 e=1;
-for o,t in pairs(t.maps)do
+for a,t in pairs(t.maps)do
 if(t.t=="genmap")then
-emit(string.format("%-20s => %s",t.to,t.from)..csel(e==a,"",","));
+emit(string.format("%-20s => %s",t.to,t.from)..csel(e==o,"",","));
 e=e+1;
 end
 end
@@ -1433,15 +1436,15 @@ indent_left();
 emit(")");
 indent_left();
 end
-if(o>0)then
+if(a>0)then
 indent_right();
 emit("port map (");
 indent_right();
 e=1;
-for a,t in pairs(t.maps)do
+for o,t in pairs(t.maps)do
 if(t.t=="portmap")then
-local a=node_typesize(t.from);
-emit(string.format("%-20s => %s",t.to,gen_subrange(a))..csel(e==o,"",","));
+local o=node_typesize(t.from);
+emit(string.format("%-20s => %s",t.to,gen_subrange(o))..csel(e==a,"",","));
 e=e+1;
 end
 end
@@ -1899,6 +1902,12 @@ cgen_write_snippet(e);
 cgen_write_snippet(t);
 cgen_write_snippet(a);
 end
+uint_t={
+[8]="uint8_t",
+[16]="uint16_t",
+[32]="uint32_t",
+[64]="uint64_t"
+}
 function cgen_c_field_define(e,a)
 local t;
 if(e.c_prefix==nil)then
@@ -1993,7 +2002,7 @@ local a=0;
 function pad_struct(t)
 if(e<t)then
 emit("/* padding to: "..t.." words */");
-emit("uint32_t __padding_"..a.."["..(t-e).."];");
+emit(uint_t[DATA_BUS_WIDTH].." __padding_"..a.."["..(t-e).."];");
 a=a+1;
 e=t;
 end
@@ -2004,7 +2013,7 @@ indent_right();
 foreach_reg({TYPE_REG},function(t)
 pad_struct(t.base);
 emit(string.format("/* [0x%x]: REG "..t.name.." */",t.base*DATA_BUS_WIDTH/8));
-emit("uint32_t "..string.upper(t.c_prefix)..";");
+emit(uint_t[DATA_BUS_WIDTH].." "..string.upper(t.c_prefix)..";");
 e=e+1;
 end);
 foreach_reg({TYPE_RAM},function(e)
@@ -2021,7 +2030,7 @@ end
 if(e.byte_select)then
 emit("uint8_t "..string.upper(e.c_prefix).." ["..(e.size*(DATA_BUS_WIDTH/8)*math.pow(2,e.wrap_bits)).."];");
 else
-emit("uint32_t "..string.upper(e.c_prefix).." ["..(e.size*math.pow(2,e.wrap_bits)).."];");
+emit(uint_t[DATA_BUS_WIDTH].." "..string.upper(e.c_prefix).." ["..(e.size*math.pow(2,e.wrap_bits)).."];");
 end
 end);
 indent_left();
@@ -2088,15 +2097,15 @@ end
 function htable_trstyle(t,a,e)
 tbl.data[t].style=e;
 end
-function htable_frame(e,t,a,o)
-if(o==nil)then
-e.data[t][a].extra='style="border: solid 1px black;"';
+function htable_frame(t,e,o,a)
+if(a==nil)then
+t.data[e][o].extra='style="border: solid 1px black;"';
 else
-e.data[t][a].extra='style="border-left: solid 1px black; border-top: solid 1px black; border-bottom: solid 1px black;';
-e.data[t][o].extra='style="border-right: solid 1px black; border-top: solid 1px black; border-bottom: solid 1px black;';
-if(o>a+1)then
-for a=a+1,o-1 do
-e.data[t][a].extra='border-top: solid 1px black; border-bottom: solid 1px black;';
+t.data[e][o].extra='style="border-left: solid 1px black; border-top: solid 1px black; border-bottom: solid 1px black;';
+t.data[e][a].extra='style="border-right: solid 1px black; border-top: solid 1px black; border-bottom: solid 1px black;';
+if(a>o+1)then
+for a=o+1,a-1 do
+t.data[e][a].extra='border-top: solid 1px black; border-bottom: solid 1px black;';
 end
 end
 end
@@ -2335,19 +2344,19 @@ e[5].text=string.upper(t.c_prefix);
 o=not o;
 end
 end);
-foreach_reg({TYPE_RAM},function(e)
-if(e.full_hdl_prefix~=nil)then
+foreach_reg({TYPE_RAM},function(t)
+if(t.full_hdl_prefix~=nil)then
 htable_add_row(i,a);
-local t=i.data[a];a=a+1;
-t.style=csel(o,"tr_odd","tr_even");
-t[1].style="td_code";
-t[1].text=string.format("0x%x - 0x%x",e.base,e.base+math.pow(2,e.wrap_bits)*e.size-1);
-t[2].text="MEM";
-t[3].text=hlink("#"..string.upper(e.c_prefix),e.name);
-t[4].style="td_code";
-t[4].text=e.full_hdl_prefix;
-t[5].style="td_code";
-t[5].text=string.upper(e.c_prefix);
+local e=i.data[a];a=a+1;
+e.style=csel(o,"tr_odd","tr_even");
+e[1].style="td_code";
+e[1].text=string.format("0x%x - 0x%x",t.base,t.base+math.pow(2,t.wrap_bits)*t.size-1);
+e[2].text="MEM";
+e[3].text=hlink("#"..string.upper(t.c_prefix),t.name);
+e[4].style="td_code";
+e[4].text=t.full_hdl_prefix;
+e[5].style="td_code";
+e[5].text=string.upper(t.c_prefix);
 o=not o;
 end
 end);
@@ -2360,20 +2369,20 @@ return a;
 end
 function cgen_doc_fieldtable(h,i)
 local e=70;
-local e;
-local t=1;
-e=htable_new(2,8);
-for t=1,8 do
-e.data[1][t].style="td_bit";
-e.data[1][t].text=string.format("%d",i+8-t);
+local t;
+local e=1;
+t=htable_new(2,8);
+for e=1,8 do
+t.data[1][e].style="td_bit";
+t.data[1][e].text=string.format("%d",i+8-e);
 end
 local a=i+7;
 while(a>=i)do
 local o=find_field_by_offset(h,a);
 if(o==nil)then
-e.data[2][t].style="td_unused";
-e.data[2][t].text="-";
-t=t+1;
+t.data[2][e].style="td_unused";
+t.data[2][e].text="-";
+e=e+1;
 a=a-1;
 else
 local n;
@@ -2384,18 +2393,18 @@ n=o.offset;
 end
 local s=(a-n)+1;
 dbg("ncells: ",s,"bit: ",a,"name: ",o.prefix);
-e.data[2][t].colspan=s;
+t.data[2][e].colspan=s;
 local i;
 i=o.c_prefix;
 if(i==nil)then i=h.c_prefix;end
-e.data[2][t].style="td_field";
-e.data[2][t].text=csel(o.size>1,string.format("%s[%d:%d]",string.upper(i),a-o.offset,n-o.offset),string.upper(i));
-htable_frame(e,2,t);
+t.data[2][e].style="td_field";
+t.data[2][e].text=csel(o.size>1,string.format("%s[%d:%d]",string.upper(i),a-o.offset,n-o.offset),string.upper(i));
+htable_frame(t,2,e);
 a=a-s;
-t=t+1;
+e=e+1;
 end
 end
-htable_emit(e);
+htable_emit(t);
 end
 function cgen_doc_access(e)
 if(e==READ_ONLY)then
@@ -3063,163 +3072,163 @@ t.ackgen_code_pre={va(e.."_int",e.."_int_delay");
 va(e.."_int_delay",0);};
 end
 end
-function gen_hdl_code_bit(t,a)
-local e=gen_hdl_field_prefix(t,a);
-t.prefix=e;
-if(t.clock==nil)then
-if(t.access==ACC_RW_RO)then
-t.ports={port(BIT,0,"out",e.."_o","Port for BIT field: '"..t.name.."' in reg: '"..a.name.."'",VPORT_REG)};
-t.signals={signal(BIT,0,e.."_int")};
-t.acklen=1;
-t.write_code={
-va(e.."_int",vi("wrdata_reg",t.offset))};
-t.read_code={va(vi("rddata_reg",t.offset),e.."_int")};
-t.reset_code_main={va(e.."_int",csel(t.reset_value==nil,0,t.reset_value))};
-t.extra_code={va(e.."_o",e.."_int")};
-elseif(t.access==ACC_RO_WO)then
-t.ports={port(BIT,0,"in",e.."_i","Port for BIT field: '"..t.name.."' in reg: '"..a.name.."'",VPORT_REG)};
-t.signals={};
-t.acklen=1;
-t.write_code={};
-t.read_code={va(vi("rddata_reg",t.offset),e.."_i")};
-t.reset_code_main={};
-t.extra_code={};
-elseif(t.access==ACC_WO_RO)then
-die("WO-RO type unsupported yet ("..t.name..")");
-elseif(t.access==ACC_RW_RW)then
-if(t.load==LOAD_EXT)then
-t.ports={port(BIT,0,"out",e.."_o","Ports for BIT field: '"..t.name.."' in reg: '"..a.name.."'",VPORT_REG),
-port(BIT,0,"in",e.."_i",nil,VPORT_REG),
-port(BIT,0,"out",e.."_load_o",nil,VPORT_REG)};
-t.acklen=1;
-t.read_code={va(vi("rddata_reg",t.offset),e.."_i")};
-t.write_code={
-va(e.."_load_o",1)};
-t.extra_code={va(e.."_o",vi("wrdata_reg",t.offset))};
-t.ackgen_code_pre={va(e.."_load_o",0)};
-t.ackgen_code={va(e.."_load_o",0)};
-t.reset_code_main={va(e.."_load_o",0)};
+function gen_hdl_code_bit(e,a)
+local t=gen_hdl_field_prefix(e,a);
+e.prefix=t;
+if(e.clock==nil)then
+if(e.access==ACC_RW_RO)then
+e.ports={port(BIT,0,"out",t.."_o","Port for BIT field: '"..e.name.."' in reg: '"..a.name.."'",VPORT_REG)};
+e.signals={signal(BIT,0,t.."_int")};
+e.acklen=1;
+e.write_code={
+va(t.."_int",vi("wrdata_reg",e.offset))};
+e.read_code={va(vi("rddata_reg",e.offset),t.."_int")};
+e.reset_code_main={va(t.."_int",csel(e.reset_value==nil,0,e.reset_value))};
+e.extra_code={va(t.."_o",t.."_int")};
+elseif(e.access==ACC_RO_WO)then
+e.ports={port(BIT,0,"in",t.."_i","Port for BIT field: '"..e.name.."' in reg: '"..a.name.."'",VPORT_REG)};
+e.signals={};
+e.acklen=1;
+e.write_code={};
+e.read_code={va(vi("rddata_reg",e.offset),t.."_i")};
+e.reset_code_main={};
+e.extra_code={};
+elseif(e.access==ACC_WO_RO)then
+die("WO-RO type unsupported yet ("..e.name..")");
+elseif(e.access==ACC_RW_RW)then
+if(e.load==LOAD_EXT)then
+e.ports={port(BIT,0,"out",t.."_o","Ports for BIT field: '"..e.name.."' in reg: '"..a.name.."'",VPORT_REG),
+port(BIT,0,"in",t.."_i",nil,VPORT_REG),
+port(BIT,0,"out",t.."_load_o",nil,VPORT_REG)};
+e.acklen=1;
+e.read_code={va(vi("rddata_reg",e.offset),t.."_i")};
+e.write_code={
+va(t.."_load_o",1)};
+e.extra_code={va(t.."_o",vi("wrdata_reg",e.offset))};
+e.ackgen_code_pre={va(t.."_load_o",0)};
+e.ackgen_code={va(t.."_load_o",0)};
+e.reset_code_main={va(t.."_load_o",0)};
 else
-die("internal RW/RW register storage unsupported yet ("..t.name..")");
+die("internal RW/RW register storage unsupported yet ("..e.name..")");
 end
 end
 else
-if(t.access==ACC_RW_RO)then
-t.ports={port(BIT,0,"out",e.."_o","Port for asynchronous (clock: "..t.clock..") BIT field: '"..t.name.."' in reg: '"..a.name.."'",VPORT_REG)};
-t.signals={signal(BIT,0,e.."_int"),
-signal(BIT,0,e.."_sync0"),
-signal(BIT,0,e.."_sync1")};
-t.acklen=4;
-t.write_code={va(e.."_int",vi("wrdata_reg",t.offset))};
-t.read_code={va(vi("rddata_reg",t.offset),e.."_int")};
-t.reset_code_main={va(e.."_int",csel(t.reset_value==nil,0,t.reset_value))};
-t.extra_code={vcomment("synchronizer chain for field : "..t.name.." (type RW/RO, clk_sys_i <-> "..t.clock..")");
-vsyncprocess(t.clock,"rst_n_i",{
+if(e.access==ACC_RW_RO)then
+e.ports={port(BIT,0,"out",t.."_o","Port for asynchronous (clock: "..e.clock..") BIT field: '"..e.name.."' in reg: '"..a.name.."'",VPORT_REG)};
+e.signals={signal(BIT,0,t.."_int"),
+signal(BIT,0,t.."_sync0"),
+signal(BIT,0,t.."_sync1")};
+e.acklen=4;
+e.write_code={va(t.."_int",vi("wrdata_reg",e.offset))};
+e.read_code={va(vi("rddata_reg",e.offset),t.."_int")};
+e.reset_code_main={va(t.."_int",csel(e.reset_value==nil,0,e.reset_value))};
+e.extra_code={vcomment("synchronizer chain for field : "..e.name.." (type RW/RO, clk_sys_i <-> "..e.clock..")");
+vsyncprocess(e.clock,"rst_n_i",{
 vreset(0,{
-va(e.."_o",csel(t.reset_value==nil,0,t.reset_value));
-va(e.."_sync0",csel(t.reset_value==nil,0,t.reset_value));
-va(e.."_sync1",csel(t.reset_value==nil,0,t.reset_value));
+va(t.."_o",csel(e.reset_value==nil,0,e.reset_value));
+va(t.."_sync0",csel(e.reset_value==nil,0,e.reset_value));
+va(t.."_sync1",csel(e.reset_value==nil,0,e.reset_value));
 });
 vposedge({
-va(e.."_sync0",e.."_int");
-va(e.."_sync1",e.."_sync0");
-va(e.."_o",e.."_sync1");
+va(t.."_sync0",t.."_int");
+va(t.."_sync1",t.."_sync0");
+va(t.."_o",t.."_sync1");
 });
 });
 };
-elseif(t.access==ACC_RO_WO)then
-t.ports={port(BIT,0,"in",e.."_i","Port for asynchronous (clock: "..t.clock..") BIT field: '"..t.name.."' in reg: '"..a.name.."'",VPORT_REG)};
-t.signals={signal(BIT,0,e.."_sync0"),
-signal(BIT,0,e.."_sync1")};
-t.acklen=1;
-t.write_code={};
-t.read_code={va(vi("rddata_reg",t.offset),e.."_sync1")};
-t.reset_code_main={};
-t.extra_code={vcomment("synchronizer chain for field : "..t.name.." (type RO/WO, "..t.clock.." -> clk_sys_i)");
-vsyncprocess(t.clock,"rst_n_i",{
+elseif(e.access==ACC_RO_WO)then
+e.ports={port(BIT,0,"in",t.."_i","Port for asynchronous (clock: "..e.clock..") BIT field: '"..e.name.."' in reg: '"..a.name.."'",VPORT_REG)};
+e.signals={signal(BIT,0,t.."_sync0"),
+signal(BIT,0,t.."_sync1")};
+e.acklen=1;
+e.write_code={};
+e.read_code={va(vi("rddata_reg",e.offset),t.."_sync1")};
+e.reset_code_main={};
+e.extra_code={vcomment("synchronizer chain for field : "..e.name.." (type RO/WO, "..e.clock.." -> clk_sys_i)");
+vsyncprocess(e.clock,"rst_n_i",{
 vreset(0,{
-va(e.."_sync0",0);
-va(e.."_sync1",0);
+va(t.."_sync0",0);
+va(t.."_sync1",0);
 });
 vposedge({
-va(e.."_sync0",e.."_i");
-va(e.."_sync1",e.."_sync0");
+va(t.."_sync0",t.."_i");
+va(t.."_sync1",t.."_sync0");
 });
 });
 };
-elseif(t.access==ACC_RW_RW)then
-if(t.load~=LOAD_EXT)then
+elseif(e.access==ACC_RW_RW)then
+if(e.load~=LOAD_EXT)then
 die("Only external load is supported for RW/RW bit fields");
 end
-local a="Ports for asynchronous (clock: "..t.clock..") RW/RW BIT field: '"..t.name.."' in reg: '"..a.name.."'";
-t.ports={port(BIT,0,"out",e.."_o",a,VPORT_REG),
-port(BIT,0,"in",e.."_i",nil,VPORT_REG),
-port(BIT,0,"out",e.."_load_o",nil,VPORT_REG)};
-t.signals={signal(BIT,0,e.."_int_read"),
-signal(BIT,0,e.."_int_write"),
-signal(BIT,0,e.."_lw"),
-signal(BIT,0,e.."_lw_delay"),
-signal(BIT,0,e.."_lw_read_in_progress"),
-signal(BIT,0,e.."_lw_s0"),
-signal(BIT,0,e.."_lw_s1"),
-signal(BIT,0,e.."_lw_s2"),
-signal(BIT,0,e.."_rwsel")};
-t.acklen=6;
-t.write_code={
-va(e.."_int_write",vi("wrdata_reg",t.offset));
-va(e.."_lw",1);
-va(e.."_lw_delay",1);
-va(e.."_lw_read_in_progress",0);
-va(e.."_rwsel",1);};
-t.read_code={vif(vequal("wb_we_i",0),{
-va(vi("rddata_reg",t.offset),vundefined());
-va(e.."_lw",1);
-va(e.."_lw_delay",1);
-va(e.."_lw_read_in_progress",1);
-va(e.."_rwsel",0);});};
-t.reset_code_main={va(e.."_lw",0);
-va(e.."_lw_delay",0);
-va(e.."_lw_read_in_progress",0);
-va(e.."_rwsel",0);
-va(e.."_int_write",0);
+local a="Ports for asynchronous (clock: "..e.clock..") RW/RW BIT field: '"..e.name.."' in reg: '"..a.name.."'";
+e.ports={port(BIT,0,"out",t.."_o",a,VPORT_REG),
+port(BIT,0,"in",t.."_i",nil,VPORT_REG),
+port(BIT,0,"out",t.."_load_o",nil,VPORT_REG)};
+e.signals={signal(BIT,0,t.."_int_read"),
+signal(BIT,0,t.."_int_write"),
+signal(BIT,0,t.."_lw"),
+signal(BIT,0,t.."_lw_delay"),
+signal(BIT,0,t.."_lw_read_in_progress"),
+signal(BIT,0,t.."_lw_s0"),
+signal(BIT,0,t.."_lw_s1"),
+signal(BIT,0,t.."_lw_s2"),
+signal(BIT,0,t.."_rwsel")};
+e.acklen=6;
+e.write_code={
+va(t.."_int_write",vi("wrdata_reg",e.offset));
+va(t.."_lw",1);
+va(t.."_lw_delay",1);
+va(t.."_lw_read_in_progress",0);
+va(t.."_rwsel",1);};
+e.read_code={vif(vequal("wb_we_i",0),{
+va(vi("rddata_reg",e.offset),vundefined());
+va(t.."_lw",1);
+va(t.."_lw_delay",1);
+va(t.."_lw_read_in_progress",1);
+va(t.."_rwsel",0);});};
+e.reset_code_main={va(t.."_lw",0);
+va(t.."_lw_delay",0);
+va(t.."_lw_read_in_progress",0);
+va(t.."_rwsel",0);
+va(t.."_int_write",0);
 };
-t.ackgen_code_pre={va(e.."_lw",e.."_lw_delay");
-va(e.."_lw_delay",0);
-vif(vand(vequal(vi("ack_sreg",1),1),vequal(e.."_lw_read_in_progress",1)),{
-va(vi("rddata_reg",t.offset),e.."_int_read");
-va(e.."_lw_read_in_progress",0);
+e.ackgen_code_pre={va(t.."_lw",t.."_lw_delay");
+va(t.."_lw_delay",0);
+vif(vand(vequal(vi("ack_sreg",1),1),vequal(t.."_lw_read_in_progress",1)),{
+va(vi("rddata_reg",e.offset),t.."_int_read");
+va(t.."_lw_read_in_progress",0);
 });
 };
-t.extra_code={vcomment("asynchronous BIT register : "..t.name.." (type RW/WO, "..t.clock.." <-> clk_sys_i)");
-vsyncprocess(t.clock,"rst_n_i",{
+e.extra_code={vcomment("asynchronous BIT register : "..e.name.." (type RW/WO, "..e.clock.." <-> clk_sys_i)");
+vsyncprocess(e.clock,"rst_n_i",{
 vreset(0,{
-va(e.."_lw_s0",0);
-va(e.."_lw_s1",0);
-va(e.."_lw_s2",0);
-va(e.."_int_read",0);
-va(e.."_load_o",0);
-va(e.."_o",0);
+va(t.."_lw_s0",0);
+va(t.."_lw_s1",0);
+va(t.."_lw_s2",0);
+va(t.."_int_read",0);
+va(t.."_load_o",0);
+va(t.."_o",0);
 });
 vposedge({
-va(e.."_lw_s0",e.."_lw");
-va(e.."_lw_s1",e.."_lw_s0");
-va(e.."_lw_s2",e.."_lw_s1");
-vif(vand(vequal(e.."_lw_s2",0),vequal(e.."_lw_s1",1)),{
-vif(vequal(e.."_rwsel",1),{
-va(e.."_o",e.."_int_write");
-va(e.."_load_o",1);
+va(t.."_lw_s0",t.."_lw");
+va(t.."_lw_s1",t.."_lw_s0");
+va(t.."_lw_s2",t.."_lw_s1");
+vif(vand(vequal(t.."_lw_s2",0),vequal(t.."_lw_s1",1)),{
+vif(vequal(t.."_rwsel",1),{
+va(t.."_o",t.."_int_write");
+va(t.."_load_o",1);
 },{
-va(e.."_load_o",0);
-va(e.."_int_read",e.."_i");
+va(t.."_load_o",0);
+va(t.."_int_read",t.."_i");
 });
 },{
-va(e.."_load_o",0);
+va(t.."_load_o",0);
 });
 });
 });
 };
-elseif(t.access==ACC_WO_RO)then
-die("WO-RO type unsupported yet ("..t.name..")");
+elseif(e.access==ACC_WO_RO)then
+die("WO-RO type unsupported yet ("..e.name..")");
 end
 end
 end
@@ -4489,7 +4498,6 @@ foreach_reg(ALL_REG_TYPES,check_obj_names_prefixes);
 foreach_field(check_obj_names_prefixes);
 periph=fix_prefix(periph);
 periph=default_wishbone_width(periph);
-print(periph.wishbone_width);
 wbgen_count_subblocks();
 wbgen_generate_eic();
 foreach_reg(ALL_REG_TYPES,fix_prefix);

--- a/wbgen_common.lua
+++ b/wbgen_common.lua
@@ -6,7 +6,7 @@
 VERBOSE_DEBUG = 0;
 
 -- bus properties
-DATA_BUS_WIDTH = 32;
+DATA_BUS_WIDTH = nil;					-- explicit initialization from .wb file
 SYNC_CHAIN_LENGTH = 3;
 
 -- constant definitions (block types)
@@ -323,6 +323,8 @@ function default_wishbone_width(obj)
 	else
 		obj.wishbone_width = 32;
 	end
+	obj.width = obj.wishbone_width;
+	DATA_BUS_WIDTH = obj.wishbone_width;
 	return obj;
 end
 

--- a/wbgen_common.lua
+++ b/wbgen_common.lua
@@ -312,6 +312,20 @@ function fix_prefix(obj)
     return obj;
 end
 
+function default_wishbone_width(obj)
+	if(obj.__type ~= TYPE_PERIPH) then
+		return obj;
+	elseif(obj.wishbone_width ~= nil) then
+		local valid_widths = { [8] = true, [16] = true, [32] = true, [64] = true };
+		if not valid_widths[obj.wishbone_width] then
+			die ("Invalid wishbone bus width '"..obj.name.."'");
+		end
+	else
+		obj.wishbone_width = 32;
+	end
+	return obj;
+end
+
 function default_access(field, mytype, acc_bus, acc_dev)
     if(field.type == mytype) then
         if(field.access_bus == nil) then

--- a/wbgen_main.lua
+++ b/wbgen_main.lua
@@ -178,6 +178,7 @@ foreach_field( check_obj_names_prefixes );
 
 
 periph = fix_prefix(periph);
+periph = default_wishbone_width(periph);
 
 wbgen_count_subblocks();
 wbgen_generate_eic();										


### PR DESCRIPTION
This pull request would implement configurable data bus widths for the wishbone bus.

As of now, the wishbone bus generated by wbgen2 is 32 bits. This is the most common setup, but with the proliferation of 64 bit processors and some niche use cases for 16 bits, it would be useful to have configurable bus widths.

Fortunately, the program already used a variable to define the bit width. It was set at 32. I added a parameter at the peripheral level to allow changing the bus width, as such:
``` Lua
peripheral {
    -- ...
    wishbone_width = 16;
}
```

The only thing missing then was modifying the C header generation. Previously, the C header (in struct mode) generated `uint32_t`  integers for every register. It now uses `uint8_t`, `uint16_t`, `uint32_t` or `uint64_t` depending on the configured width. It follows that the allowed values are 8, 16, 32 and 64. Using the C23 `bitint` type could allow for any value, but this is outside the scope of this work.

The data bus width remains dynamic, and the generated C code (in define mode) defaults to 32 bit addresses that are presumably truncated and/or translated by the HDL interface code that the user writes between the processor and the generated Wishbone peripheral.

Done:
* Implement feature
* Test feature on hardware

Pending:
* Documentation updates